### PR TITLE
LoRa Component using SX126x or SX127x

### DIFF
--- a/esphome/components/lora/__init__.py
+++ b/esphome/components/lora/__init__.py
@@ -17,31 +17,6 @@ DOMAIN = "lora"
 
 CONF_LORA_ID = "lora_id"
 
-# CONF_BANDWIDTH = "bandwidth"
-# CONF_CODING_RATE = "coding_rate"
-# CONF_PAYLOAD_LENGTH = "payload_length"
-# CONF_PREAMBLE_SIZE = "preamble_size"
-# CONF_SPREADING_FACTOR = "spreading_factor"
-
-# BANDWIDTHS = [
-#     "7_8kHz",
-#     "10_4kHz",
-#     "15_6kHz",
-#     "20_8kHz",
-#     "31_3kHz",
-#     "41_7kHz",
-#     "62_5kHz",
-#     "125_0kHz",
-#     "250_0kHz",
-#     "500_0kHz",
-# ]
-# CODING_RATES = [
-#     "CR_4_5",
-#     "CR_4_6",
-#     "CR_4_7",
-#     "CR_4_8",
-# ]
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,26 +27,12 @@ LORA_SCHEMA = cv.Schema(
     }
 )
 
-# def validate_(config):
-#     if config[CONF_PREAMBLE_SIZE] > 0 and config[CONF_PREAMBLE_SIZE] < 6:
-#         raise cv.Invalid("Minimum preamble size is 6 with LORA")
-#     if config[CONF_SPREADING_FACTOR] == 6 and config[CONF_PAYLOAD_LENGTH] == 0:
-#         raise cv.Invalid("Payload length must be set when spreading factor is 6")
-#     return config
 
-
-LORA_COMPONENT_SCHEMA = (
-    cv.Schema(
-        {
-            # cv.Optional(CONF_BANDWIDTH, default="125_0kHz"): cv.one_of(BANDWIDTHS),
-            # cv.Optional(CONF_CODING_RATE, default="CR_4_5"): cv.one_of(CODING_RATES),
-            # cv.Optional(CONF_PAYLOAD_LENGTH, default=0): cv.int_range(min=0, max=256),
-            # cv.Optional(CONF_PREAMBLE_SIZE, default=0): cv.int_range(min=0, max=65535),
-            # cv.Optional(CONF_SPREADING_FACTOR, default=7): cv.int_range(min=6, max=12),
-        }
-    ).extend(cv.COMPONENT_SCHEMA)
-    # .add_extra(validate_)
-)
+LORA_COMPONENT_SCHEMA = cv.Schema(
+    {
+        # Place to add generic LoRa-specific config parameters
+    }
+).extend(cv.COMPONENT_SCHEMA)
 
 
 async def register_lora_client(var, config):

--- a/esphome/components/lora/__init__.py
+++ b/esphome/components/lora/__init__.py
@@ -16,57 +16,70 @@ IS_PLATFORM_COMPONENT = True
 DOMAIN = "lora"
 
 CONF_LORA_ID = "lora_id"
+CONF_RADIO_ID = "radio_id"
 
-CONF_BANDWIDTH = "bandwidth"
-CONF_CODING_RATE = "coding_rate"
-CONF_PAYLOAD_LENGTH = "payload_length"
-CONF_PREAMBLE_SIZE = "preamble_size"
-CONF_SPREADING_FACTOR = "spreading_factor"
 
-BANDWIDTHS = [
-    "7_8kHz",
-    "10_4kHz",
-    "15_6kHz",
-    "20_8kHz",
-    "31_3kHz",
-    "41_7kHz",
-    "62_5kHz",
-    "125_0kHz",
-    "250_0kHz",
-    "500_0kHz",
-]
-CODING_RATES = [
-    "CR_4_5",
-    "CR_4_6",
-    "CR_4_7",
-    "CR_4_8",
-]
+# CONF_BANDWIDTH = "bandwidth"
+# CONF_CODING_RATE = "coding_rate"
+# CONF_PAYLOAD_LENGTH = "payload_length"
+# CONF_PREAMBLE_SIZE = "preamble_size"
+# CONF_SPREADING_FACTOR = "spreading_factor"
+
+# BANDWIDTHS = [
+#     "7_8kHz",
+#     "10_4kHz",
+#     "15_6kHz",
+#     "20_8kHz",
+#     "31_3kHz",
+#     "41_7kHz",
+#     "62_5kHz",
+#     "125_0kHz",
+#     "250_0kHz",
+#     "500_0kHz",
+# ]
+# CODING_RATES = [
+#     "CR_4_5",
+#     "CR_4_6",
+#     "CR_4_7",
+#     "CR_4_8",
+# ]
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def validate_(config):
-    if config[CONF_PREAMBLE_SIZE] > 0 and config[CONF_PREAMBLE_SIZE] < 6:
-        raise cv.Invalid("Minimum preamble size is 6 with LORA")
-    if config[CONF_SPREADING_FACTOR] == 6 and config[CONF_PAYLOAD_LENGTH] == 0:
-        raise cv.Invalid("Payload length must be set when spreading factor is 6")
-    return config
+LORA_ID_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_LORA_ID): cv.use_id(LoRa),
+    }
+)
+
+# def validate_(config):
+#     if config[CONF_PREAMBLE_SIZE] > 0 and config[CONF_PREAMBLE_SIZE] < 6:
+#         raise cv.Invalid("Minimum preamble size is 6 with LORA")
+#     if config[CONF_SPREADING_FACTOR] == 6 and config[CONF_PAYLOAD_LENGTH] == 0:
+#         raise cv.Invalid("Payload length must be set when spreading factor is 6")
+#     return config
 
 
 LORA_SCHEMA = (
     cv.Schema(
         {
-            cv.Optional(CONF_BANDWIDTH, default="125_0kHz"): cv.one_of(BANDWIDTHS),
-            cv.Optional(CONF_CODING_RATE, default="CR_4_5"): cv.one_of(CODING_RATES),
-            cv.Optional(CONF_PAYLOAD_LENGTH, default=0): cv.int_range(min=0, max=256),
-            cv.Optional(CONF_PREAMBLE_SIZE, default=0): cv.int_range(min=0, max=65535),
-            cv.Optional(CONF_SPREADING_FACTOR, default=7): cv.int_range(min=6, max=12),
+            # cv.Optional(CONF_BANDWIDTH, default="125_0kHz"): cv.one_of(BANDWIDTHS),
+            # cv.Optional(CONF_CODING_RATE, default="CR_4_5"): cv.one_of(CODING_RATES),
+            # cv.Optional(CONF_PAYLOAD_LENGTH, default=0): cv.int_range(min=0, max=256),
+            # cv.Optional(CONF_PREAMBLE_SIZE, default=0): cv.int_range(min=0, max=65535),
+            # cv.Optional(CONF_SPREADING_FACTOR, default=7): cv.int_range(min=6, max=12),
         }
-    )
-    .extend(cv.COMPONENT_SCHEMA)
-    .add_extra(validate_)
+    ).extend(cv.COMPONENT_SCHEMA)
+    # .add_extra(validate_)
 )
+
+
+async def register_lora_client(var, config):
+    lora_var = await cg.get_variable(config[CONF_LORA_ID])
+    cg.add(var.set_parent(lora_var))
+    return lora_var
 
 
 def lora_schema(cls):

--- a/esphome/components/lora/__init__.py
+++ b/esphome/components/lora/__init__.py
@@ -13,14 +13,24 @@ lora_ns = cg.esphome_ns.namespace("lora")
 LoRa = lora_ns.class_("LoRa", cg.Component)
 LoRaListener = lora_ns.class_("LoRaListener")
 
-# RunImageCalAction = lora_ns.class_("RunImageCalAction", automation.Action)
+# RunImageCalAction = lora_ns.class_(
+#     "RunImageCalAction", automation.Action, cg.Parented.template(LoRa)
+# )
 SendPacketAction = lora_ns.class_(
     "SendPacketAction", automation.Action, cg.Parented.template(LoRa)
 )
-SetModeTxAction = lora_ns.class_("SetModeTxAction", automation.Action)
-SetModeRxAction = lora_ns.class_("SetModeRxAction", automation.Action)
-SetModeSleepAction = lora_ns.class_("SetModeSleepAction", automation.Action)
-SetModeStandbyAction = lora_ns.class_("SetModeStandbyAction", automation.Action)
+SetModeTxAction = lora_ns.class_(
+    "SetModeTxAction", automation.Action, cg.Parented.template(LoRa)
+)
+SetModeRxAction = lora_ns.class_(
+    "SetModeRxAction", automation.Action, cg.Parented.template(LoRa)
+)
+SetModeSleepAction = lora_ns.class_(
+    "SetModeSleepAction", automation.Action, cg.Parented.template(LoRa)
+)
+SetModeStandbyAction = lora_ns.class_(
+    "SetModeStandbyAction", automation.Action, cg.Parented.template(LoRa)
+)
 
 IS_PLATFORM_COMPONENT = True
 

--- a/esphome/components/lora/__init__.py
+++ b/esphome/components/lora/__init__.py
@@ -1,0 +1,80 @@
+"""ESPHome LoRa component."""
+
+import logging
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_PLATFORM
+
+CODEOWNERS = ["@dala318"]
+
+lora_ns = cg.esphome_ns.namespace("lora")
+LoRa = lora_ns.class_("LoRa", cg.Component)
+
+IS_PLATFORM_COMPONENT = True
+
+DOMAIN = "lora"
+
+CONF_LORA_ID = "lora_id"
+
+CONF_BANDWIDTH = "bandwidth"
+CONF_CODING_RATE = "coding_rate"
+CONF_PAYLOAD_LENGTH = "payload_length"
+CONF_PREAMBLE_SIZE = "preamble_size"
+CONF_SPREADING_FACTOR = "spreading_factor"
+
+BANDWIDTHS = [
+    "7_8kHz",
+    "10_4kHz",
+    "15_6kHz",
+    "20_8kHz",
+    "31_3kHz",
+    "41_7kHz",
+    "62_5kHz",
+    "125_0kHz",
+    "250_0kHz",
+    "500_0kHz",
+]
+CODING_RATES = [
+    "CR_4_5",
+    "CR_4_6",
+    "CR_4_7",
+    "CR_4_8",
+]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def validate_(config):
+    if config[CONF_PREAMBLE_SIZE] > 0 and config[CONF_PREAMBLE_SIZE] < 6:
+        raise cv.Invalid("Minimum preamble size is 6 with LORA")
+    if config[CONF_SPREADING_FACTOR] == 6 and config[CONF_PAYLOAD_LENGTH] == 0:
+        raise cv.Invalid("Payload length must be set when spreading factor is 6")
+    return config
+
+
+LORA_SCHEMA = (
+    cv.Schema(
+        {
+            cv.Optional(CONF_BANDWIDTH, default="125_0kHz"): cv.one_of(BANDWIDTHS),
+            cv.Optional(CONF_CODING_RATE, default="CR_4_5"): cv.one_of(CODING_RATES),
+            cv.Optional(CONF_PAYLOAD_LENGTH, default=0): cv.int_range(min=0, max=256),
+            cv.Optional(CONF_PREAMBLE_SIZE, default=0): cv.int_range(min=0, max=65535),
+            cv.Optional(CONF_SPREADING_FACTOR, default=7): cv.int_range(min=6, max=12),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .add_extra(validate_)
+)
+
+
+def lora_schema(cls):
+    return LORA_SCHEMA.extend({cv.GenerateID(): cv.declare_id(cls)})
+
+
+async def new_lora(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    cg.add(var.set_platform_name(config[CONF_PLATFORM]))
+    await cg.register_component(var, config)
+    return var

--- a/esphome/components/lora/__init__.py
+++ b/esphome/components/lora/__init__.py
@@ -10,6 +10,7 @@ CODEOWNERS = ["@dala318"]
 
 lora_ns = cg.esphome_ns.namespace("lora")
 LoRa = lora_ns.class_("LoRa", cg.Component)
+LoRaListener = lora_ns.class_("LoRaListener")
 
 IS_PLATFORM_COMPONENT = True
 

--- a/esphome/components/lora/__init__.py
+++ b/esphome/components/lora/__init__.py
@@ -2,15 +2,25 @@
 
 import logging
 
+from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_PLATFORM
+from esphome.const import CONF_DATA, CONF_ID, CONF_ON_MESSAGE, CONF_PLATFORM
 
 CODEOWNERS = ["@dala318"]
 
 lora_ns = cg.esphome_ns.namespace("lora")
 LoRa = lora_ns.class_("LoRa", cg.Component)
 LoRaListener = lora_ns.class_("LoRaListener")
+
+# RunImageCalAction = lora_ns.class_("RunImageCalAction", automation.Action)
+SendPacketAction = lora_ns.class_(
+    "SendPacketAction", automation.Action, cg.Parented.template(LoRa)
+)
+SetModeTxAction = lora_ns.class_("SetModeTxAction", automation.Action)
+SetModeRxAction = lora_ns.class_("SetModeRxAction", automation.Action)
+SetModeSleepAction = lora_ns.class_("SetModeSleepAction", automation.Action)
+SetModeStandbyAction = lora_ns.class_("SetModeStandbyAction", automation.Action)
 
 IS_PLATFORM_COMPONENT = True
 
@@ -31,7 +41,7 @@ LORA_SCHEMA = cv.Schema(
 
 LORA_COMPONENT_SCHEMA = cv.Schema(
     {
-        # Place to add generic LoRa-specific config parameters
+        cv.Optional(CONF_ON_MESSAGE): automation.validate_automation(single=True),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -50,4 +60,76 @@ async def new_lora(config):
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_platform_name(config[CONF_PLATFORM]))
     await cg.register_component(var, config)
+    if CONF_ON_MESSAGE in config:
+        await automation.build_automation(
+            var.get_packet_trigger(),
+            [
+                (cg.std_vector.template(cg.uint8), "x"),
+                (cg.float_, "rssi"),
+                (cg.float_, "snr"),
+            ],
+            config[CONF_ON_MESSAGE],
+        )
+    return var
+
+
+NO_ARGS_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(LoRa),
+    }
+)
+
+
+# @automation.register_action(
+#     "lora.run_image_cal", RunImageCalAction, NO_ARGS_ACTION_SCHEMA
+# )
+@automation.register_action("lora.set_mode_tx", SetModeTxAction, NO_ARGS_ACTION_SCHEMA)
+@automation.register_action("lora.set_mode_rx", SetModeRxAction, NO_ARGS_ACTION_SCHEMA)
+@automation.register_action(
+    "lora.set_mode_sleep", SetModeSleepAction, NO_ARGS_ACTION_SCHEMA
+)
+@automation.register_action(
+    "lora.set_mode_standby", SetModeStandbyAction, NO_ARGS_ACTION_SCHEMA
+)
+async def no_args_action_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    return var
+
+
+def validate_raw_data(value):
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return cv.Schema([cv.hex_uint8_t])(value)
+    raise cv.Invalid(
+        "data must either be a string wrapped in quotes or a list of bytes"
+    )
+
+
+SEND_PACKET_ACTION_SCHEMA = cv.maybe_simple_value(
+    {
+        cv.GenerateID(): cv.use_id(LoRa),
+        cv.Required(CONF_DATA): cv.templatable(validate_raw_data),
+    },
+    key=CONF_DATA,
+)
+
+
+@automation.register_action(
+    "lora.send_packet", SendPacketAction, SEND_PACKET_ACTION_SCHEMA
+)
+async def send_packet_action_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    data = config[CONF_DATA]
+    if isinstance(data, bytes):
+        data = list(data)
+    if cg.is_template(data):
+        templ = await cg.templatable(data, args, cg.std_vector.template(cg.uint8))
+        cg.add(var.set_data_template(templ))
+    else:
+        cg.add(var.set_data_static(data))
     return var

--- a/esphome/components/lora/__init__.py
+++ b/esphome/components/lora/__init__.py
@@ -16,8 +16,6 @@ IS_PLATFORM_COMPONENT = True
 DOMAIN = "lora"
 
 CONF_LORA_ID = "lora_id"
-CONF_RADIO_ID = "radio_id"
-
 
 # CONF_BANDWIDTH = "bandwidth"
 # CONF_CODING_RATE = "coding_rate"
@@ -48,7 +46,7 @@ CONF_RADIO_ID = "radio_id"
 _LOGGER = logging.getLogger(__name__)
 
 
-LORA_ID_SCHEMA = cv.Schema(
+LORA_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_LORA_ID): cv.use_id(LoRa),
     }
@@ -62,7 +60,7 @@ LORA_ID_SCHEMA = cv.Schema(
 #     return config
 
 
-LORA_SCHEMA = (
+LORA_COMPONENT_SCHEMA = (
     cv.Schema(
         {
             # cv.Optional(CONF_BANDWIDTH, default="125_0kHz"): cv.one_of(BANDWIDTHS),
@@ -83,7 +81,7 @@ async def register_lora_client(var, config):
 
 
 def lora_schema(cls):
-    return LORA_SCHEMA.extend({cv.GenerateID(): cv.declare_id(cls)})
+    return LORA_COMPONENT_SCHEMA.extend({cv.GenerateID(): cv.declare_id(cls)})
 
 
 async def new_lora(config):

--- a/esphome/components/lora/automation.h
+++ b/esphome/components/lora/automation.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "lora.h"
+
+namespace esphome {
+namespace lora {
+
+// template<typename... Ts> class RunImageCalAction : public Action<Ts...> {
+//  public:
+//   RunImageCalAction(LoRa *lora) : lora_(lora) {}
+
+//   void play(Ts... x) override { this->lora_->run_image_cal(); }
+
+//  protected:
+//   LoRa *lora_;
+// };
+
+template<typename... Ts> class SendPacketAction : public Action<Ts...>, public Parented<LoRa> {
+ public:
+  void set_data_template(std::function<std::vector<uint8_t>(Ts...)> func) {
+    this->data_func_ = func;
+    this->static_ = false;
+  }
+  void set_data_static(const std::vector<uint8_t> &data) {
+    this->data_static_ = data;
+    this->static_ = true;
+  }
+
+  void play(Ts... x) override {
+    if (this->static_) {
+      this->parent_->send_packet(this->data_static_);
+    } else {
+      this->parent_->send_packet(this->data_func_(x...));
+    }
+  }
+
+ protected:
+  bool static_{false};
+  std::function<std::vector<uint8_t>(Ts...)> data_func_{};
+  std::vector<uint8_t> data_static_{};
+};
+
+template<typename... Ts> class SetModeTxAction : public Action<Ts...> {
+ public:
+  SetModeTxAction(LoRa *lora) : lora_(lora) {}
+
+  void play(Ts... x) override { this->lora_->set_mode(LoRaMode::TX); }
+
+ protected:
+  LoRa *lora_;
+};
+
+template<typename... Ts> class SetModeRxAction : public Action<Ts...> {
+ public:
+  SetModeRxAction(LoRa *lora) : lora_(lora) {}
+
+  void play(Ts... x) override { this->lora_->set_mode(LoRaMode::RX); }
+
+ protected:
+  LoRa *lora_;
+};
+
+template<typename... Ts> class SetModeSleepAction : public Action<Ts...> {
+ public:
+  SetModeSleepAction(LoRa *lora) : lora_(lora) {}
+
+  void play(Ts... x) override { this->lora_->set_mode(LoRaMode::SLEEP); }
+
+ protected:
+  LoRa *lora_;
+};
+
+template<typename... Ts> class SetModeStandbyAction : public Action<Ts...> {
+ public:
+  SetModeStandbyAction(LoRa *lora) : lora_(lora) {}
+
+  void play(Ts... x) override { this->lora_->set_mode(LoRaMode::STANDBY); }
+
+ protected:
+  LoRa *lora_;
+};
+
+}  // namespace lora
+}  // namespace esphome

--- a/esphome/components/lora/automation.h
+++ b/esphome/components/lora/automation.h
@@ -7,14 +7,9 @@
 namespace esphome {
 namespace lora {
 
-// template<typename... Ts> class RunImageCalAction : public Action<Ts...> {
+// template<typename... Ts> class RunImageCalAction : public Action<Ts...>, public Parented<LoRa> {
 //  public:
-//   RunImageCalAction(LoRa *lora) : lora_(lora) {}
-
-//   void play(Ts... x) override { this->lora_->run_image_cal(); }
-
-//  protected:
-//   LoRa *lora_;
+//   void play(Ts... x) override { this->parent_->run_image_cal(); }
 // };
 
 template<typename... Ts> class SendPacketAction : public Action<Ts...>, public Parented<LoRa> {
@@ -42,44 +37,24 @@ template<typename... Ts> class SendPacketAction : public Action<Ts...>, public P
   std::vector<uint8_t> data_static_{};
 };
 
-template<typename... Ts> class SetModeTxAction : public Action<Ts...> {
+template<typename... Ts> class SetModeTxAction : public Action<Ts...>, public Parented<LoRa> {
  public:
-  SetModeTxAction(LoRa *lora) : lora_(lora) {}
-
-  void play(Ts... x) override { this->lora_->set_mode(LoRaMode::TX); }
-
- protected:
-  LoRa *lora_;
+  void play(Ts... x) override { this->parent_->set_mode(LoRaMode::TX); }
 };
 
-template<typename... Ts> class SetModeRxAction : public Action<Ts...> {
+template<typename... Ts> class SetModeRxAction : public Action<Ts...>, public Parented<LoRa> {
  public:
-  SetModeRxAction(LoRa *lora) : lora_(lora) {}
-
-  void play(Ts... x) override { this->lora_->set_mode(LoRaMode::RX); }
-
- protected:
-  LoRa *lora_;
+  void play(Ts... x) override { this->parent_->set_mode(LoRaMode::RX); }
 };
 
-template<typename... Ts> class SetModeSleepAction : public Action<Ts...> {
+template<typename... Ts> class SetModeSleepAction : public Action<Ts...>, public Parented<LoRa> {
  public:
-  SetModeSleepAction(LoRa *lora) : lora_(lora) {}
-
-  void play(Ts... x) override { this->lora_->set_mode(LoRaMode::SLEEP); }
-
- protected:
-  LoRa *lora_;
+  void play(Ts... x) override { this->parent_->set_mode(LoRaMode::SLEEP); }
 };
 
-template<typename... Ts> class SetModeStandbyAction : public Action<Ts...> {
+template<typename... Ts> class SetModeStandbyAction : public Action<Ts...>, public Parented<LoRa> {
  public:
-  SetModeStandbyAction(LoRa *lora) : lora_(lora) {}
-
-  void play(Ts... x) override { this->lora_->set_mode(LoRaMode::STANDBY); }
-
- protected:
-  LoRa *lora_;
+  void play(Ts... x) override { this->parent_->set_mode(LoRaMode::STANDBY); }
 };
 
 }  // namespace lora

--- a/esphome/components/lora/lora.cpp
+++ b/esphome/components/lora/lora.cpp
@@ -10,10 +10,6 @@ static const char *const TAG = "lora";
 void LoRa::dump_config() {
   ESP_LOGCONFIG(TAG, "LoRa:");
   ESP_LOGCONFIG(TAG, "  Platform: %s", this->platform_name_);
-  // ESP_LOGCONFIG(TAG, "  Radio: %s", this->parent_->get_name().c_str());
-  // ESP_LOGCONFIG(TAG, "  Encrypted: %s", YESNO(this->is_encrypted_()));
-  // ESP_LOGCONFIG(TAG, "  Ping-pong: %s", YESNO(this->ping_pong_enable_));
-  // Component::dump_config();
 }
 
 void LoRa::packet_received(const std::vector<uint8_t> &packet, float rssi, float snr) {

--- a/esphome/components/lora/lora.cpp
+++ b/esphome/components/lora/lora.cpp
@@ -1,0 +1,25 @@
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include "lora.h"
+
+namespace esphome {
+namespace lora {
+
+static const char *const TAG = "lora";
+
+void LoRa::packet_received(const std::vector<uint8_t> &packet, float rssi, float snr) {
+  ESP_LOGD(TAG, "packet %s", format_hex(packet).c_str());
+  ESP_LOGD(TAG, "rssi %.2f", rssi);
+  ESP_LOGD(TAG, "snr %.2f", snr);
+  this->call_listeners_(packet, rssi, snr);
+}
+
+void LoRa::call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr) {
+  for (auto &listener : this->listeners_) {
+    listener->on_packet(packet, rssi, snr);
+  }
+  this->packet_trigger_->trigger(packet, rssi, snr);
+}
+
+}  // namespace lora
+}  // namespace esphome

--- a/esphome/components/lora/lora.cpp
+++ b/esphome/components/lora/lora.cpp
@@ -7,6 +7,15 @@ namespace lora {
 
 static const char *const TAG = "lora";
 
+void LoRa::dump_config() {
+  ESP_LOGCONFIG(TAG, "LoRa:");
+  ESP_LOGCONFIG(TAG, "  Platform: %s", this->platform_name_);
+  // ESP_LOGCONFIG(TAG, "  Radio: %s", this->parent_->get_name().c_str());
+  // ESP_LOGCONFIG(TAG, "  Encrypted: %s", YESNO(this->is_encrypted_()));
+  // ESP_LOGCONFIG(TAG, "  Ping-pong: %s", YESNO(this->ping_pong_enable_));
+  // Component::dump_config();
+}
+
 void LoRa::packet_received(const std::vector<uint8_t> &packet, float rssi, float snr) {
   ESP_LOGD(TAG, "packet %s", format_hex(packet).c_str());
   ESP_LOGD(TAG, "rssi %.2f", rssi);

--- a/esphome/components/lora/lora.h
+++ b/esphome/components/lora/lora.h
@@ -16,7 +16,7 @@ class LoRaListener {
 
 class LoRa : public Component {
  public:
-  // EspHome default functions
+  // ESPHome default function overrides
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
@@ -26,11 +26,13 @@ class LoRa : public Component {
   // Radio config functions
   virtual void set_frequency(uint32_t frequency) = 0;
   virtual void set_mode(LoRaMode mode) = 0;
+  virtual size_t get_max_packet_size() = 0;
+
   // Radio operational functions
   void packet_received(const std::vector<uint8_t> &packet, float rssi, float snr);
   virtual void send_packet(const std::vector<uint8_t> &buf) const = 0;
 
-  // Listener functions
+  // On data event registration functions
   void register_listener(LoRaListener *listener) { this->listeners_.push_back(listener); }
   Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() const { return this->packet_trigger_; };
 

--- a/esphome/components/lora/lora.h
+++ b/esphome/components/lora/lora.h
@@ -15,7 +15,7 @@ class LoRa : public Component {
  public:
   void dump_config() override;
   void packet_received(const std::vector<uint8_t> &packet, float rssi, float snr);
-  virtual void send_packet(std::vector<uint8_t> &buf) const = 0;
+  virtual void send_packet(const std::vector<uint8_t> &buf) const = 0;
   void register_listener(LoRaListener *listener) { this->listeners_.push_back(listener); }
   Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() const { return this->packet_trigger_; };
   void set_platform_name(const char *name) { this->platform_name_ = name; }

--- a/esphome/components/lora/lora.h
+++ b/esphome/components/lora/lora.h
@@ -6,10 +6,22 @@
 namespace esphome {
 namespace lora {
 
+class LoRaListener {
+ public:
+  virtual void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr);
+};
+
 class LoRa : public Component {
  public:
-  virtual void send_packet(const std::vector<uint8_t> &data) = 0;
-  virtual bool receive_packet(std::vector<uint8_t> &data) = 0;
+  void packet_received(const std::vector<uint8_t> &packet, float rssi, float snr);
+  virtual void send_packet(std::vector<uint8_t> &buf) const = 0;
+  void register_listener(LoRaListener *listener) { this->listeners_.push_back(listener); }
+  Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() const { return this->packet_trigger_; };
+
+ protected:
+  void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
+  std::vector<LoRaListener *> listeners_;
+  Trigger<std::vector<uint8_t>, float, float> *packet_trigger_{new Trigger<std::vector<uint8_t>, float, float>()};
 };
 
 }  // namespace lora

--- a/esphome/components/lora/lora.h
+++ b/esphome/components/lora/lora.h
@@ -14,11 +14,12 @@ class LoRaListener {
 class LoRa : public Component {
  public:
   void dump_config() override;
+  void set_platform_name(const char *name) { this->platform_name_ = name; }
+  virtual void set_frequency(uint32_t frequency) = 0;
   void packet_received(const std::vector<uint8_t> &packet, float rssi, float snr);
   virtual void send_packet(const std::vector<uint8_t> &buf) const = 0;
   void register_listener(LoRaListener *listener) { this->listeners_.push_back(listener); }
   Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() const { return this->packet_trigger_; };
-  void set_platform_name(const char *name) { this->platform_name_ = name; }
 
  protected:
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);

--- a/esphome/components/lora/lora.h
+++ b/esphome/components/lora/lora.h
@@ -7,7 +7,9 @@
 namespace esphome {
 namespace lora {
 
-enum class LoRaMode { SLEEP, STANDBY, RX, TX };
+enum class LoRaCommandResponse { OK, UNSUPPORTED_FEATURE, UNKNOWN_VALUE, ERROR };
+
+enum class LoRaMode { INIT, WAKEUP, SLEEP, STANDBY, RX, TX };
 
 class LoRaListener {
  public:
@@ -24,8 +26,10 @@ class LoRa : public Component {
   void set_platform_name(const char *name) { this->platform_name_ = name; }
 
   // Radio config functions
-  virtual void set_frequency(uint32_t frequency) = 0;
-  virtual void set_mode(LoRaMode mode) = 0;
+  virtual LoRaCommandResponse set_frequency(uint32_t frequency) = 0;
+  virtual LoRaCommandResponse set_mode(LoRaMode mode) = 0;
+
+  // Radio information
   virtual size_t get_max_packet_size() = 0;
 
   // Radio operational functions

--- a/esphome/components/lora/lora.h
+++ b/esphome/components/lora/lora.h
@@ -13,19 +13,28 @@ class LoRaListener {
 
 class LoRa : public Component {
  public:
+  // EspHome default functions
   void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  // Config setter functions
   void set_platform_name(const char *name) { this->platform_name_ = name; }
   virtual void set_frequency(uint32_t frequency) = 0;
+
+  // Operational functions
   void packet_received(const std::vector<uint8_t> &packet, float rssi, float snr);
   virtual void send_packet(const std::vector<uint8_t> &buf) const = 0;
+
+  // Listener functions
   void register_listener(LoRaListener *listener) { this->listeners_.push_back(listener); }
   Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() const { return this->packet_trigger_; };
 
  protected:
-  void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
-  std::vector<LoRaListener *> listeners_;
-  Trigger<std::vector<uint8_t>, float, float> *packet_trigger_{new Trigger<std::vector<uint8_t>, float, float>()};
   const char *platform_name_{""};
+
+  std::vector<LoRaListener *> listeners_;
+  void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
+  Trigger<std::vector<uint8_t>, float, float> *packet_trigger_{new Trigger<std::vector<uint8_t>, float, float>()};
 };
 
 }  // namespace lora

--- a/esphome/components/lora/lora.h
+++ b/esphome/components/lora/lora.h
@@ -13,15 +13,18 @@ class LoRaListener {
 
 class LoRa : public Component {
  public:
+  void dump_config() override;
   void packet_received(const std::vector<uint8_t> &packet, float rssi, float snr);
   virtual void send_packet(std::vector<uint8_t> &buf) const = 0;
   void register_listener(LoRaListener *listener) { this->listeners_.push_back(listener); }
   Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() const { return this->packet_trigger_; };
+  void set_platform_name(const char *name) { this->platform_name_ = name; }
 
  protected:
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   std::vector<LoRaListener *> listeners_;
   Trigger<std::vector<uint8_t>, float, float> *packet_trigger_{new Trigger<std::vector<uint8_t>, float, float>()};
+  const char *platform_name_{""};
 };
 
 }  // namespace lora

--- a/esphome/components/lora/lora.h
+++ b/esphome/components/lora/lora.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "esphome/core/component.h"
+
+#include <vector>
+
+namespace esphome {
+namespace lora {
+
+class LoRa : public Component {
+ public:
+  virtual void send_packet(const std::vector<uint8_t> &data) = 0;
+  virtual bool receive_packet(std::vector<uint8_t> &data) = 0;
+};
+
+}  // namespace lora
+}  // namespace esphome

--- a/esphome/components/lora/lora.h
+++ b/esphome/components/lora/lora.h
@@ -1,10 +1,13 @@
 #pragma once
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
 #include <vector>
 
 namespace esphome {
 namespace lora {
+
+enum class LoRaMode { SLEEP, STANDBY, RX, TX };
 
 class LoRaListener {
  public:
@@ -19,9 +22,11 @@ class LoRa : public Component {
 
   // Config setter functions
   void set_platform_name(const char *name) { this->platform_name_ = name; }
-  virtual void set_frequency(uint32_t frequency) = 0;
 
-  // Operational functions
+  // Radio config functions
+  virtual void set_frequency(uint32_t frequency) = 0;
+  virtual void set_mode(LoRaMode mode) = 0;
+  // Radio operational functions
   void packet_received(const std::vector<uint8_t> &packet, float rssi, float snr);
   virtual void send_packet(const std::vector<uint8_t> &buf) const = 0;
 

--- a/esphome/components/lora/packet_transport/__init__.py
+++ b/esphome/components/lora/packet_transport/__init__.py
@@ -1,0 +1,27 @@
+import esphome.codegen as cg
+from esphome.components.packet_transport import (
+    PacketTransport,
+    new_packet_transport,
+    transport_schema,
+)
+import esphome.config_validation as cv
+from esphome.cpp_types import PollingComponent
+
+from .. import CONF_LORA_ID, LoRa, LoRaListener, lora_ns
+
+LoRaTransport = lora_ns.class_(
+    "LoRaTransport", PacketTransport, PollingComponent, LoRaListener
+)
+
+CONFIG_SCHEMA = transport_schema(LoRaTransport).extend(
+    {
+        cv.GenerateID(CONF_LORA_ID): cv.use_id(LoRa),
+    }
+)
+
+
+async def to_code(config):
+    var, _ = await new_packet_transport(config)
+    lora = await cg.get_variable(config[CONF_LORA_ID])
+    cg.add(var.set_parent(lora))
+    cg.add(lora.register_listener(var))

--- a/esphome/components/lora/packet_transport/lora_transport.cpp
+++ b/esphome/components/lora/packet_transport/lora_transport.cpp
@@ -14,7 +14,7 @@ void LoRaTransport::update() {
   this->resend_data_ = true;
 }
 
-void LoRaTransport::send_packet(std::vector<uint8_t> &buf) const { this->parent_->send_packet(buf); }
+void LoRaTransport::send_packet(const std::vector<uint8_t> &buf) const { this->parent_->send_packet(buf); }
 
 void LoRaTransport::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) {
   std::vector<uint8_t> temp = packet;

--- a/esphome/components/lora/packet_transport/lora_transport.cpp
+++ b/esphome/components/lora/packet_transport/lora_transport.cpp
@@ -1,0 +1,25 @@
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include "esphome/components/network/util.h"
+#include "lora_transport.h"
+
+namespace esphome {
+namespace lora {
+
+static const char *const TAG = "lora_transport";
+
+void LoRaTransport::update() {
+  PacketTransport::update();
+  this->updated_ = true;
+  this->resend_data_ = true;
+}
+
+void LoRaTransport::send_packet(std::vector<uint8_t> &buf) const { this->parent_->send_packet(buf); }
+
+void LoRaTransport::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) {
+  std::vector<uint8_t> temp = packet;
+  this->process_(temp);
+}
+
+}  // namespace lora
+}  // namespace esphome

--- a/esphome/components/lora/packet_transport/lora_transport.h
+++ b/esphome/components/lora/packet_transport/lora_transport.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/lora/lora.h"
+#include "esphome/components/packet_transport/packet_transport.h"
+#include <vector>
+
+namespace esphome {
+namespace lora {
+
+class LoRaTransport : public packet_transport::PacketTransport, public Parented<LoRa>, public LoRaListener {
+ public:
+  void update() override;
+  void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+ protected:
+  void send_packet(std::vector<uint8_t> &buf) const override;
+  bool should_send() override { return true; }
+  size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
+};
+
+}  // namespace lora
+}  // namespace esphome

--- a/esphome/components/lora/packet_transport/lora_transport.h
+++ b/esphome/components/lora/packet_transport/lora_transport.h
@@ -15,7 +15,7 @@ class LoRaTransport : public packet_transport::PacketTransport, public Parented<
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
  protected:
-  void send_packet(std::vector<uint8_t> &buf) const override;
+  void send_packet(const std::vector<uint8_t> &buf) const override;
   bool should_send() override { return true; }
   size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
 };

--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -30,6 +30,7 @@ CONF_RX_START = "rx_start"
 CONF_RF_SWITCH = "rf_switch"
 CONF_SHAPING = "shaping"
 CONF_SPREADING_FACTOR = "spreading_factor"
+CONF_SX126X_ID = "sx126x_id"
 CONF_SYNC_VALUE = "sync_value"
 CONF_TCXO_VOLTAGE = "tcxo_voltage"
 CONF_TCXO_DELAY = "tcxo_delay"
@@ -43,6 +44,12 @@ SX126xTcxoCtrl = sx126x_ns.enum("SX126xTcxoCtrl")
 SX126xRampTime = sx126x_ns.enum("SX126xRampTime")
 SX126xPulseShape = sx126x_ns.enum("SX126xPulseShape")
 SX126xLoraCr = sx126x_ns.enum("SX126xLoraCr")
+
+SX126X_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_SX126X_ID): cv.use_id(SX126x),
+    }
+)
 
 BW = {
     "4_8kHz": SX126xBw.SX126X_BW_4800,
@@ -140,6 +147,9 @@ SetModeStandbyAction = sx126x_ns.class_(
     "SetModeStandbyAction", automation.Action, cg.Parented.template(SX126x)
 )
 
+# Work-around to ensure that the sx127x component is set in modulation LORA when used in LoRa Component
+sx126x_modes = {}
+
 
 def validate_raw_data(value):
     if isinstance(value, str):
@@ -154,6 +164,7 @@ def validate_raw_data(value):
 
 
 def validate_config(config):
+    sx126x_modes[str(config[CONF_ID])] = config[CONF_MODULATION]
     lora_bws = [
         "7_8kHz",
         "10_4kHz",
@@ -224,6 +235,12 @@ CONFIG_SCHEMA = (
     .extend(spi.spi_device_schema(True, 8e6, "mode0"))
     .add_extra(validate_config)
 )
+
+
+async def register_sx126x_client(var, config):
+    sx126x_var = await cg.get_variable(config[CONF_SX126X_ID])
+    cg.add(var.set_parent(sx126x_var))
+    return sx126x_var
 
 
 async def to_code(config):

--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -30,7 +30,6 @@ CONF_RX_START = "rx_start"
 CONF_RF_SWITCH = "rf_switch"
 CONF_SHAPING = "shaping"
 CONF_SPREADING_FACTOR = "spreading_factor"
-CONF_SX126X_ID = "sx126x_id"
 CONF_SYNC_VALUE = "sync_value"
 CONF_TCXO_VOLTAGE = "tcxo_voltage"
 CONF_TCXO_DELAY = "tcxo_delay"
@@ -44,12 +43,6 @@ SX126xTcxoCtrl = sx126x_ns.enum("SX126xTcxoCtrl")
 SX126xRampTime = sx126x_ns.enum("SX126xRampTime")
 SX126xPulseShape = sx126x_ns.enum("SX126xPulseShape")
 SX126xLoraCr = sx126x_ns.enum("SX126xLoraCr")
-
-SX126X_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_SX126X_ID): cv.use_id(SX126x),
-    }
-)
 
 BW = {
     "4_8kHz": SX126xBw.SX126X_BW_4800,
@@ -235,12 +228,6 @@ CONFIG_SCHEMA = (
     .extend(spi.spi_device_schema(True, 8e6, "mode0"))
     .add_extra(validate_config)
 )
-
-
-async def register_sx126x_client(var, config):
-    sx126x_var = await cg.get_variable(config[CONF_SX126X_ID])
-    cg.add(var.set_parent(sx126x_var))
-    return sx126x_var
 
 
 async def to_code(config):

--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -140,9 +140,6 @@ SetModeStandbyAction = sx126x_ns.class_(
     "SetModeStandbyAction", automation.Action, cg.Parented.template(SX126x)
 )
 
-# Work-around to ensure that the sx127x component is set in modulation LORA when used in LoRa Component
-sx126x_modes = {}
-
 
 def validate_raw_data(value):
     if isinstance(value, str):
@@ -157,7 +154,6 @@ def validate_raw_data(value):
 
 
 def validate_config(config):
-    sx126x_modes[str(config[CONF_ID])] = config[CONF_MODULATION]
     lora_bws = [
         "7_8kHz",
         "10_4kHz",

--- a/esphome/components/sx126x/lora/__init__.py
+++ b/esphome/components/sx126x/lora/__init__.py
@@ -8,8 +8,8 @@ import esphome.final_validate as fv
 from .. import (
     CONF_MODULATION,
     CONF_SX126X_ID,
-    CONFIG_SCHEMA as SX126X_CONFIG_SCHEMA,
-    MOD,
+    # CONFIG_SCHEMA as SX126X_CONFIG_SCHEMA,
+    # MOD,
     SX126x,
     SX126xListener,
     sx126x_ns,
@@ -25,15 +25,18 @@ REFERENCE_CONFIG_SCHEMA = lora_schema(SX126xLoRa).extend(
     }
 )
 
+# Using combined LoRa and SX126x config schema does not work as the SX126x component
+# files one level up are not automatically copied to the build directory.
 
-INCLUDE_CONFIG_SCHEMA = SX126X_CONFIG_SCHEMA.extend(lora_schema(SX126xLoRa)).extend(
-    {
-        cv.GenerateID(CONF_SX126X_ID): cv.declare_id(SX126x),
-        cv.Optional(CONF_MODULATION, default="LORA"): cv.enum({"LORA": MOD["LORA"]}),
-    }
-)
+# INCLUDE_CONFIG_SCHEMA = SX126X_CONFIG_SCHEMA.extend(lora_schema(SX126xLoRa)).extend(
+#     {
+#         cv.GenerateID(CONF_SX126X_ID): cv.declare_id(SX126x),
+#         cv.Optional(CONF_MODULATION, default="LORA"): cv.enum({"LORA": MOD["LORA"]}),
+#     }
+# )
 
-CONFIG_SCHEMA = cv.Any(REFERENCE_CONFIG_SCHEMA, INCLUDE_CONFIG_SCHEMA)
+# CONFIG_SCHEMA = cv.Any(REFERENCE_CONFIG_SCHEMA, INCLUDE_CONFIG_SCHEMA)
+CONFIF_SCHEMA = REFERENCE_CONFIG_SCHEMA
 
 
 def _final_validate(config):

--- a/esphome/components/sx126x/lora/__init__.py
+++ b/esphome/components/sx126x/lora/__init__.py
@@ -1,0 +1,36 @@
+from esphome.components.lora import LoRa, lora_schema, new_lora
+import esphome.config_validation as cv
+from esphome.cpp_types import Component
+
+from .. import (
+    CONF_SX126X_ID,
+    SX126X_SCHEMA,
+    register_sx126x_client,
+    sx126x_modes,
+    sx126x_ns,
+)
+
+SX126xLoRa = sx126x_ns.class_("SX126xLoRa", LoRa, Component)
+
+
+def validate_lora(config):
+    radio_id = str(config[CONF_SX126X_ID])
+    mode = sx126x_modes.get(radio_id)
+    if mode is not None and mode != "LORA":
+        raise cv.Invalid(
+            f"SX126x comonent {radio_id} is not configured in modulation LORA"
+        )
+    return config
+
+
+CONFIG_SCHEMA = lora_schema(SX126xLoRa).extend(SX126X_SCHEMA).add_extra(validate_lora)
+
+
+async def to_code(config):
+    # Call the validate_lora function here as well, config validation is none in the
+    # order as defined in config.yaml, so if lora is configured before sx126x, the
+    # sx126x mode will not be set yet.
+    validate_lora(config)
+
+    var = await new_lora(config)
+    await register_sx126x_client(var, config)

--- a/esphome/components/sx126x/lora/__init__.py
+++ b/esphome/components/sx126x/lora/__init__.py
@@ -30,7 +30,7 @@ CONFIG_SCHEMA = (
 
 
 async def to_code(config):
-    # Call the validate_lora function here as well, config validation is none in the
+    # Call the validate_lora function here as well, config validation is done in the
     # order as defined in config.yaml, so if lora is configured before sx126x, the
     # sx126x mode will not be set yet.
     validate_lora(config)

--- a/esphome/components/sx126x/lora/__init__.py
+++ b/esphome/components/sx126x/lora/__init__.py
@@ -1,16 +1,11 @@
+import esphome.codegen as cg
 from esphome.components.lora import LoRa, lora_schema, new_lora
 import esphome.config_validation as cv
 from esphome.cpp_types import Component
 
-from .. import (
-    CONF_SX126X_ID,
-    SX126X_SCHEMA,
-    register_sx126x_client,
-    sx126x_modes,
-    sx126x_ns,
-)
+from .. import CONF_SX126X_ID, SX126x, SX126xListener, sx126x_modes, sx126x_ns
 
-SX126xLoRa = sx126x_ns.class_("SX126xLoRa", LoRa, Component)
+SX126xLoRa = sx126x_ns.class_("SX126xLoRa", LoRa, Component, SX126xListener)
 
 
 def validate_lora(config):
@@ -23,7 +18,15 @@ def validate_lora(config):
     return config
 
 
-CONFIG_SCHEMA = lora_schema(SX126xLoRa).extend(SX126X_SCHEMA).add_extra(validate_lora)
+CONFIG_SCHEMA = (
+    lora_schema(SX126xLoRa)
+    .extend(
+        {
+            cv.GenerateID(CONF_SX126X_ID): cv.use_id(SX126x),
+        }
+    )
+    .add_extra(validate_lora)
+)
 
 
 async def to_code(config):
@@ -33,4 +36,6 @@ async def to_code(config):
     validate_lora(config)
 
     var = await new_lora(config)
-    await register_sx126x_client(var, config)
+    sx126x = await cg.get_variable(config[CONF_SX126X_ID])
+    cg.add(var.set_parent(sx126x))
+    cg.add(sx126x.register_listener(var))

--- a/esphome/components/sx126x/lora/__init__.py
+++ b/esphome/components/sx126x/lora/__init__.py
@@ -3,6 +3,7 @@ from esphome.components.lora import LoRa, lora_schema, new_lora
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 from esphome.cpp_types import Component
+import esphome.final_validate as fv
 
 from .. import (
     CONF_MODULATION,
@@ -11,7 +12,6 @@ from .. import (
     MOD,
     SX126x,
     SX126xListener,
-    sx126x_modes,
     sx126x_ns,
     to_code as sx126x_to_code,
 )
@@ -19,24 +19,10 @@ from .. import (
 SX126xLoRa = sx126x_ns.class_("SX126xLoRa", LoRa, Component, SX126xListener)
 
 
-def validate_lora(config):
-    radio_id = str(config[CONF_SX126X_ID])
-    mode = sx126x_modes.get(radio_id)
-    if mode is not None and mode != "LORA":
-        raise cv.Invalid(
-            f"SX126x comonent {radio_id} is not configured in modulation LORA"
-        )
-    return config
-
-
-REFERENCE_CONFIG_SCHEMA = (
-    lora_schema(SX126xLoRa)
-    .extend(
-        {
-            cv.GenerateID(CONF_SX126X_ID): cv.use_id(SX126x),
-        }
-    )
-    .add_extra(validate_lora)
+REFERENCE_CONFIG_SCHEMA = lora_schema(SX126xLoRa).extend(
+    {
+        cv.GenerateID(CONF_SX126X_ID): cv.use_id(SX126x),
+    }
 )
 
 
@@ -50,14 +36,24 @@ INCLUDE_CONFIG_SCHEMA = SX126X_CONFIG_SCHEMA.extend(lora_schema(SX126xLoRa)).ext
 CONFIG_SCHEMA = cv.Any(REFERENCE_CONFIG_SCHEMA, INCLUDE_CONFIG_SCHEMA)
 
 
+def _final_validate(config):
+    full_config = fv.full_config.get()
+    sx_path = full_config.get_path_for_id(config[CONF_SX126X_ID])[:-1]
+    sx_config = full_config.get_config_for_path(sx_path)
+
+    mode = sx_config.get(CONF_MODULATION)
+    if mode is not None and mode != "LORA":
+        raise cv.Invalid(
+            f"SX126x comonent {config[CONF_SX126X_ID]} is not configured in modulation LORA"
+        )
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
+
 async def to_code(config):
     # LoRa Config with ref to other SX126x is expected to have been provided
     if CONF_MODULATION not in config:
-        # Call the validate_lora function here as well, config validation is done in the
-        # order as defined in config.yaml, so if lora is configured before sx126x, the
-        # sx126x mode will not be set yet.
-        validate_lora(config)
-
         var = await new_lora(config)
         sx126x = await cg.get_variable(config[CONF_SX126X_ID])
         cg.add(var.set_parent(sx126x))

--- a/esphome/components/sx126x/lora/__init__.py
+++ b/esphome/components/sx126x/lora/__init__.py
@@ -1,9 +1,20 @@
 import esphome.codegen as cg
 from esphome.components.lora import LoRa, lora_schema, new_lora
 import esphome.config_validation as cv
+from esphome.const import CONF_ID
 from esphome.cpp_types import Component
 
-from .. import CONF_SX126X_ID, SX126x, SX126xListener, sx126x_modes, sx126x_ns
+from .. import (
+    CONF_MODULATION,
+    CONF_SX126X_ID,
+    CONFIG_SCHEMA as SX126X_CONFIG_SCHEMA,
+    MOD,
+    SX126x,
+    SX126xListener,
+    sx126x_modes,
+    sx126x_ns,
+    to_code as sx126x_to_code,
+)
 
 SX126xLoRa = sx126x_ns.class_("SX126xLoRa", LoRa, Component, SX126xListener)
 
@@ -18,7 +29,7 @@ def validate_lora(config):
     return config
 
 
-CONFIG_SCHEMA = (
+REFERENCE_CONFIG_SCHEMA = (
     lora_schema(SX126xLoRa)
     .extend(
         {
@@ -29,13 +40,38 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
-    # Call the validate_lora function here as well, config validation is done in the
-    # order as defined in config.yaml, so if lora is configured before sx126x, the
-    # sx126x mode will not be set yet.
-    validate_lora(config)
+INCLUDE_CONFIG_SCHEMA = SX126X_CONFIG_SCHEMA.extend(lora_schema(SX126xLoRa)).extend(
+    {
+        cv.GenerateID(CONF_SX126X_ID): cv.declare_id(SX126x),
+        cv.Optional(CONF_MODULATION, default="LORA"): cv.enum({"LORA": MOD["LORA"]}),
+    }
+)
 
-    var = await new_lora(config)
-    sx126x = await cg.get_variable(config[CONF_SX126X_ID])
-    cg.add(var.set_parent(sx126x))
-    cg.add(sx126x.register_listener(var))
+CONFIG_SCHEMA = cv.Any(REFERENCE_CONFIG_SCHEMA, INCLUDE_CONFIG_SCHEMA)
+
+
+async def to_code(config):
+    # LoRa Config with ref to other SX126x is expected to have been provided
+    if CONF_MODULATION not in config:
+        # Call the validate_lora function here as well, config validation is done in the
+        # order as defined in config.yaml, so if lora is configured before sx126x, the
+        # sx126x mode will not be set yet.
+        validate_lora(config)
+
+        var = await new_lora(config)
+        sx126x = await cg.get_variable(config[CONF_SX126X_ID])
+        cg.add(var.set_parent(sx126x))
+        cg.add(sx126x.register_listener(var))
+
+    # LoRa Config with full SX126x module config is provided
+    else:
+        # Create the sx126x component
+        sx126x_config = config.copy()
+        sx126x_config[CONF_ID] = config[CONF_SX126X_ID]
+        await sx126x_to_code(sx126x_config)
+
+        # Create the lora component
+        var = await new_lora(config)
+        sx126x = await cg.get_variable(config[CONF_SX126X_ID])
+        cg.add(var.set_parent(sx126x))
+        cg.add(sx126x.register_listener(var))

--- a/esphome/components/sx126x/lora/sx126x_lora.cpp
+++ b/esphome/components/sx126x/lora/sx126x_lora.cpp
@@ -7,17 +7,6 @@ namespace sx126x {
 
 static const char *const TAG = "sx126x_lora";
 
-SX126xLoRaListener::SX126xLoRaListener(SX126xLoRa *parent) { this->parent_ = parent; }
-
-void SX126xLoRaListener::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) {
-  this->parent_->packet_received(packet, rssi, snr);
-}
-
-void SX126xLoRa::setup() {
-  LoRa::setup();
-  this->parent_->register_listener(new SX126xLoRaListener(this));
-}
-
 void SX126xLoRa::set_frequency(uint32_t frequency) {
   this->parent_->set_frequency(frequency);
   this->parent_->configure();

--- a/esphome/components/sx126x/lora/sx126x_lora.cpp
+++ b/esphome/components/sx126x/lora/sx126x_lora.cpp
@@ -1,0 +1,27 @@
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include "sx126x_lora.h"
+
+namespace esphome {
+namespace sx126x {
+
+static const char *const TAG = "sx126x_lora";
+
+SX126xLoRaListener::SX126xLoRaListener(SX126xLoRa *parent) { this->parent_ = parent; }
+
+void SX126xLoRaListener::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) {
+  this->parent_->packet_received(packet, rssi, snr);
+}
+
+void SX126xLoRa::setup() {
+  LoRa::setup();
+  this->parent_->register_listener(new SX126xLoRaListener(this));
+}
+
+void SX126xLoRa::set_frequency(uint32_t frequency) {
+  this->parent_->set_frequency(frequency);
+  this->parent_->configure();
+}
+
+}  // namespace sx126x
+}  // namespace esphome

--- a/esphome/components/sx126x/lora/sx126x_lora.cpp
+++ b/esphome/components/sx126x/lora/sx126x_lora.cpp
@@ -5,28 +5,37 @@
 namespace esphome {
 namespace sx126x {
 
+using namespace esphome::lora;
+
 static const char *const TAG = "sx126x_lora";
 
-void SX126xLoRa::set_frequency(uint32_t frequency) {
+LoRaCommandResponse SX126xLoRa::set_frequency(uint32_t frequency) {
   this->parent_->set_frequency(frequency);
   this->parent_->configure();
+  return LoRaCommandResponse::OK;
 }
 
-void SX126xLoRa::set_mode(lora::LoRaMode mode) {
+LoRaCommandResponse SX126xLoRa::set_mode(LoRaMode mode) {
   switch (mode) {
-    case lora::LoRaMode::SLEEP:
+    case LoRaMode::INIT:
+      this->parent_->configure();
+      break;
+    case LoRaMode::WAKEUP:
+      return LoRaCommandResponse::UNSUPPORTED_FEATURE;
+    case LoRaMode::SLEEP:
       this->parent_->set_mode_sleep();
       break;
-    case lora::LoRaMode::STANDBY:
-      this->parent_->set_mode_standby();
+    case LoRaMode::STANDBY:
+      this->parent_->set_mode_standby(SX126xStandbyMode::STDBY_RC);
       break;
-    case lora::LoRaMode::RX:
+    case LoRaMode::RX:
       this->parent_->set_mode_rx();
       break;
-    case lora::LoRaMode::TX:
+    case LoRaMode::TX:
       this->parent_->set_mode_tx();
       break;
   }
+  return LoRaCommandResponse::OK;
 }
 
 }  // namespace sx126x

--- a/esphome/components/sx126x/lora/sx126x_lora.cpp
+++ b/esphome/components/sx126x/lora/sx126x_lora.cpp
@@ -12,5 +12,22 @@ void SX126xLoRa::set_frequency(uint32_t frequency) {
   this->parent_->configure();
 }
 
+void SX126xLoRa::set_mode(lora::LoRaMode mode) {
+  switch (mode) {
+    case lora::LoRaMode::SLEEP:
+      this->parent_->set_mode_sleep();
+      break;
+    case lora::LoRaMode::STANDBY:
+      this->parent_->set_mode_standby();
+      break;
+    case lora::LoRaMode::RX:
+      this->parent_->set_mode_rx();
+      break;
+    case lora::LoRaMode::TX:
+      this->parent_->set_mode_tx();
+      break;
+  }
+}
+
 }  // namespace sx126x
 }  // namespace esphome

--- a/esphome/components/sx126x/lora/sx126x_lora.h
+++ b/esphome/components/sx126x/lora/sx126x_lora.h
@@ -1,33 +1,24 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/sx126x/sx126x.h"
 #include "esphome/components/lora/lora.h"
 #include <vector>
-#include "../sx126x.h"
 
 namespace esphome {
 namespace sx126x {
 
-class SX126xLoRa;
-
-class SX126xLoRaListener : public SX126xListener {
+class SX126xLoRa : public lora::LoRa, public Parented<SX126x>, public SX126xListener {
  public:
-  SX126xLoRaListener(SX126xLoRa *parent);
-  void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override;
-
- protected:
-  SX126xLoRa *parent_;
-};
-
-class SX126xLoRa : public lora::LoRa, public Parented<SX126x> {
- public:
-  void setup() override;
+  void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override {
+    this->packet_received(packet, rssi, snr);
+  }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void send_packet(const std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
   void set_frequency(uint32_t frequency) override;
 
  protected:
-  // size_t get_max_packet_size() override { return 255u; }
+  // size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
 };
 
 }  // namespace sx126x

--- a/esphome/components/sx126x/lora/sx126x_lora.h
+++ b/esphome/components/sx126x/lora/sx126x_lora.h
@@ -15,7 +15,9 @@ class SX126xLoRa : public lora::LoRa, public Parented<SX126x>, public SX126xList
   }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void send_packet(const std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
+
   void set_frequency(uint32_t frequency) override;
+  void set_mode(lora::LoRaMode mode) override;
 
  protected:
   // size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }

--- a/esphome/components/sx126x/lora/sx126x_lora.h
+++ b/esphome/components/sx126x/lora/sx126x_lora.h
@@ -8,7 +8,9 @@
 namespace esphome {
 namespace sx126x {
 
-class SX126xLoRa : public lora::LoRa, public Parented<SX126x>, public SX126xListener {
+using namespace esphome::lora;
+
+class SX126xLoRa : public LoRa, public Parented<SX126x>, public SX126xListener {
  public:
   void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override {
     this->packet_received(packet, rssi, snr);
@@ -16,8 +18,8 @@ class SX126xLoRa : public lora::LoRa, public Parented<SX126x>, public SX126xList
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void send_packet(const std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
 
-  void set_frequency(uint32_t frequency) override;
-  void set_mode(lora::LoRaMode mode) override;
+  LoRaCommandResponse set_frequency(uint32_t frequency) override;
+  LoRaCommandResponse set_mode(LoRaMode mode) override;
 
   size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
 };

--- a/esphome/components/sx126x/lora/sx126x_lora.h
+++ b/esphome/components/sx126x/lora/sx126x_lora.h
@@ -19,8 +19,7 @@ class SX126xLoRa : public lora::LoRa, public Parented<SX126x>, public SX126xList
   void set_frequency(uint32_t frequency) override;
   void set_mode(lora::LoRaMode mode) override;
 
- protected:
-  // size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
+  size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
 };
 
 }  // namespace sx126x

--- a/esphome/components/sx126x/lora/sx126x_lora.h
+++ b/esphome/components/sx126x/lora/sx126x_lora.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/lora/lora.h"
+#include <vector>
+#include "../sx126x.h"
+
+namespace esphome {
+namespace sx126x {
+
+class SX126xLoRa;
+
+class SX126xLoRaListener : public SX126xListener {
+ public:
+  SX126xLoRaListener(SX126xLoRa *parent);
+  void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override;
+
+ protected:
+  SX126xLoRa *parent_;
+};
+
+class SX126xLoRa : public lora::LoRa, public Parented<SX126x> {
+ public:
+  void setup() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+  void send_packet(const std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
+  void set_frequency(uint32_t frequency) override;
+
+ protected:
+  // size_t get_max_packet_size() override { return 255u; }
+};
+
+}  // namespace sx126x
+}  // namespace esphome

--- a/esphome/components/sx127x/__init__.py
+++ b/esphome/components/sx127x/__init__.py
@@ -135,6 +135,9 @@ SetModeStandbyAction = sx127x_ns.class_(
     "SetModeStandbyAction", automation.Action, cg.Parented.template(SX127x)
 )
 
+# Work-around to ensure that the sx127x component is set in modulation LORA when used in LoRa Component
+sx127x_modes = {}
+
 
 def validate_raw_data(value):
     if isinstance(value, str):
@@ -149,6 +152,7 @@ def validate_raw_data(value):
 
 
 def validate_config(config):
+    sx127x_modes[str(config[CONF_ID])] = config[CONF_MODULATION]
     if config[CONF_MODULATION] == "LORA":
         bws = [
             "7_8kHz",

--- a/esphome/components/sx127x/__init__.py
+++ b/esphome/components/sx127x/__init__.py
@@ -135,9 +135,6 @@ SetModeStandbyAction = sx127x_ns.class_(
     "SetModeStandbyAction", automation.Action, cg.Parented.template(SX127x)
 )
 
-# Work-around to ensure that the sx127x component is set in modulation LORA when used in LoRa Component
-sx127x_modes = {}
-
 
 def validate_raw_data(value):
     if isinstance(value, str):
@@ -152,7 +149,6 @@ def validate_raw_data(value):
 
 
 def validate_config(config):
-    sx127x_modes[str(config[CONF_ID])] = config[CONF_MODULATION]
     if config[CONF_MODULATION] == "LORA":
         bws = [
             "7_8kHz",

--- a/esphome/components/sx127x/lora/__init__.py
+++ b/esphome/components/sx127x/lora/__init__.py
@@ -8,8 +8,8 @@ import esphome.final_validate as fv
 from .. import (
     CONF_MODULATION,
     CONF_SX127X_ID,
-    CONFIG_SCHEMA as SX127X_CONFIG_SCHEMA,
-    MOD,
+    # CONFIG_SCHEMA as SX127X_CONFIG_SCHEMA,
+    # MOD,
     SX127x,
     SX127xListener,
     sx127x_ns,
@@ -25,14 +25,18 @@ REFERENCE_CONFIG_SCHEMA = lora_schema(SX127xLoRa).extend(
     }
 )
 
-INCLUDE_CONFIG_SCHEMA = SX127X_CONFIG_SCHEMA.extend(lora_schema(SX127xLoRa)).extend(
-    {
-        cv.GenerateID(CONF_SX127X_ID): cv.declare_id(SX127x),
-        cv.Optional(CONF_MODULATION, default="LORA"): cv.enum({"LORA": MOD["LORA"]}),
-    }
-)
+# Using combined LoRa and SX127x config schema does not work as the SX127x component
+# files one level up are not automatically copied to the build directory.
 
-CONFIG_SCHEMA = cv.Any(REFERENCE_CONFIG_SCHEMA, INCLUDE_CONFIG_SCHEMA)
+# INCLUDE_CONFIG_SCHEMA = SX127X_CONFIG_SCHEMA.extend(lora_schema(SX127xLoRa)).extend(
+#     {
+#         cv.GenerateID(CONF_SX127X_ID): cv.declare_id(SX127x),
+#         cv.Optional(CONF_MODULATION, default="LORA"): cv.enum({"LORA": MOD["LORA"]}),
+#     }
+# )
+
+# CONFIG_SCHEMA = cv.Any(REFERENCE_CONFIG_SCHEMA, INCLUDE_CONFIG_SCHEMA)
+CONFIG_SCHEMA = REFERENCE_CONFIG_SCHEMA
 
 
 def _final_validate(config):

--- a/esphome/components/sx127x/lora/__init__.py
+++ b/esphome/components/sx127x/lora/__init__.py
@@ -1,9 +1,20 @@
 import esphome.codegen as cg
 from esphome.components.lora import LoRa, lora_schema, new_lora
 import esphome.config_validation as cv
+from esphome.const import CONF_ID
 from esphome.cpp_types import Component
 
-from .. import CONF_SX127X_ID, SX127x, SX127xListener, sx127x_modes, sx127x_ns
+from .. import (
+    CONF_MODULATION,
+    CONF_SX127X_ID,
+    CONFIG_SCHEMA as SX127X_CONFIG_SCHEMA,
+    MOD,
+    SX127x,
+    SX127xListener,
+    sx127x_modes,
+    sx127x_ns,
+    to_code as sx127x_to_code,
+)
 
 SX127xLoRa = sx127x_ns.class_("SX127xLoRa", LoRa, Component, SX127xListener)
 
@@ -18,7 +29,7 @@ def validate_lora(config):
     return config
 
 
-CONFIG_SCHEMA = (
+REFERENCE_CONFIG_SCHEMA = (
     lora_schema(SX127xLoRa)
     .extend(
         {
@@ -28,14 +39,38 @@ CONFIG_SCHEMA = (
     .add_extra(validate_lora)
 )
 
+INCLUDE_CONFIG_SCHEMA = SX127X_CONFIG_SCHEMA.extend(lora_schema(SX127xLoRa)).extend(
+    {
+        cv.GenerateID(CONF_SX127X_ID): cv.declare_id(SX127x),
+        cv.Optional(CONF_MODULATION, default="LORA"): cv.enum({"LORA": MOD["LORA"]}),
+    }
+)
+
+CONFIG_SCHEMA = cv.Any(REFERENCE_CONFIG_SCHEMA, INCLUDE_CONFIG_SCHEMA)
+
 
 async def to_code(config):
-    # Call the validate_lora function here as well, config validation is done in the
-    # order as defined in config.yaml, so if lora is configured before sx127x, the
-    # sx127x mode will not be set yet.
-    validate_lora(config)
+    # LoRa Config with ref to other SX127x is expected to have been provided
+    if CONF_MODULATION not in config:
+        # Call the validate_lora function here as well, config validation is done in the
+        # order as defined in config.yaml, so if lora is configured before sx127x, the
+        # sx127x mode will not be set yet.
+        validate_lora(config)
 
-    var = await new_lora(config)
-    sx127x = await cg.get_variable(config[CONF_SX127X_ID])
-    cg.add(var.set_parent(sx127x))
-    cg.add(sx127x.register_listener(var))
+        var = await new_lora(config)
+        sx127x = await cg.get_variable(config[CONF_SX127X_ID])
+        cg.add(var.set_parent(sx127x))
+        cg.add(sx127x.register_listener(var))
+
+    # LoRa Config with full SX127x module config is provided
+    else:
+        # Create the sx127x component
+        sx127x_config = config.copy()
+        sx127x_config[CONF_ID] = config[CONF_SX127X_ID]
+        await sx127x_to_code(sx127x_config)
+
+        # Create the lora component
+        var = await new_lora(config)
+        sx127x = await cg.get_variable(config[CONF_SX127X_ID])
+        cg.add(var.set_parent(sx127x))
+        cg.add(sx127x.register_listener(var))

--- a/esphome/components/sx127x/lora/__init__.py
+++ b/esphome/components/sx127x/lora/__init__.py
@@ -3,6 +3,7 @@ from esphome.components.lora import LoRa, lora_schema, new_lora
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 from esphome.cpp_types import Component
+import esphome.final_validate as fv
 
 from .. import (
     CONF_MODULATION,
@@ -11,7 +12,6 @@ from .. import (
     MOD,
     SX127x,
     SX127xListener,
-    sx127x_modes,
     sx127x_ns,
     to_code as sx127x_to_code,
 )
@@ -19,24 +19,10 @@ from .. import (
 SX127xLoRa = sx127x_ns.class_("SX127xLoRa", LoRa, Component, SX127xListener)
 
 
-def validate_lora(config):
-    radio_id = str(config[CONF_SX127X_ID])
-    mode = sx127x_modes.get(radio_id)
-    if mode is not None and mode != "LORA":
-        raise cv.Invalid(
-            f"SX127x comonent {radio_id} is not configured in modulation LORA"
-        )
-    return config
-
-
-REFERENCE_CONFIG_SCHEMA = (
-    lora_schema(SX127xLoRa)
-    .extend(
-        {
-            cv.GenerateID(CONF_SX127X_ID): cv.use_id(SX127x),
-        }
-    )
-    .add_extra(validate_lora)
+REFERENCE_CONFIG_SCHEMA = lora_schema(SX127xLoRa).extend(
+    {
+        cv.GenerateID(CONF_SX127X_ID): cv.use_id(SX127x),
+    }
 )
 
 INCLUDE_CONFIG_SCHEMA = SX127X_CONFIG_SCHEMA.extend(lora_schema(SX127xLoRa)).extend(
@@ -49,14 +35,24 @@ INCLUDE_CONFIG_SCHEMA = SX127X_CONFIG_SCHEMA.extend(lora_schema(SX127xLoRa)).ext
 CONFIG_SCHEMA = cv.Any(REFERENCE_CONFIG_SCHEMA, INCLUDE_CONFIG_SCHEMA)
 
 
+def _final_validate(config):
+    full_config = fv.full_config.get()
+    sx_path = full_config.get_path_for_id(config[CONF_SX127X_ID])[:-1]
+    sx_config = full_config.get_config_for_path(sx_path)
+
+    mode = sx_config.get(CONF_MODULATION)
+    if mode is not None and mode != "LORA":
+        raise cv.Invalid(
+            f"SX127x comonent {config[CONF_SX127X_ID]} is not configured in modulation LORA"
+        )
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
+
 async def to_code(config):
     # LoRa Config with ref to other SX127x is expected to have been provided
     if CONF_MODULATION not in config:
-        # Call the validate_lora function here as well, config validation is done in the
-        # order as defined in config.yaml, so if lora is configured before sx127x, the
-        # sx127x mode will not be set yet.
-        validate_lora(config)
-
         var = await new_lora(config)
         sx127x = await cg.get_variable(config[CONF_SX127X_ID])
         cg.add(var.set_parent(sx127x))

--- a/esphome/components/sx127x/lora/__init__.py
+++ b/esphome/components/sx127x/lora/__init__.py
@@ -1,0 +1,13 @@
+from esphome.components.lora import LoRa, lora_schema, new_lora
+from esphome.cpp_types import Component
+
+from .. import SX127X_SCHEMA, register_sx127x_client, sx127x_ns
+
+SX127xLoRa = sx127x_ns.class_("SX127xLoRa", LoRa, Component)
+
+CONFIG_SCHEMA = lora_schema(SX127xLoRa).extend(SX127X_SCHEMA)
+
+
+async def to_code(config):
+    var = await new_lora(config)
+    await register_sx127x_client(var, config)

--- a/esphome/components/sx127x/lora/__init__.py
+++ b/esphome/components/sx127x/lora/__init__.py
@@ -1,16 +1,11 @@
+import esphome.codegen as cg
 from esphome.components.lora import LoRa, lora_schema, new_lora
 import esphome.config_validation as cv
 from esphome.cpp_types import Component
 
-from .. import (
-    CONF_SX127X_ID,
-    SX127X_SCHEMA,
-    register_sx127x_client,
-    sx127x_modes,
-    sx127x_ns,
-)
+from .. import CONF_SX127X_ID, SX127x, SX127xListener, sx127x_modes, sx127x_ns
 
-SX127xLoRa = sx127x_ns.class_("SX127xLoRa", LoRa, Component)
+SX127xLoRa = sx127x_ns.class_("SX127xLoRa", LoRa, Component, SX127xListener)
 
 
 def validate_lora(config):
@@ -23,7 +18,15 @@ def validate_lora(config):
     return config
 
 
-CONFIG_SCHEMA = lora_schema(SX127xLoRa).extend(SX127X_SCHEMA).add_extra(validate_lora)
+CONFIG_SCHEMA = (
+    lora_schema(SX127xLoRa)
+    .extend(
+        {
+            cv.GenerateID(CONF_SX127X_ID): cv.use_id(SX127x),
+        }
+    )
+    .add_extra(validate_lora)
+)
 
 
 async def to_code(config):
@@ -33,4 +36,6 @@ async def to_code(config):
     validate_lora(config)
 
     var = await new_lora(config)
-    await register_sx127x_client(var, config)
+    sx127x = await cg.get_variable(config[CONF_SX127X_ID])
+    cg.add(var.set_parent(sx127x))
+    cg.add(sx127x.register_listener(var))

--- a/esphome/components/sx127x/lora/__init__.py
+++ b/esphome/components/sx127x/lora/__init__.py
@@ -30,7 +30,7 @@ CONFIG_SCHEMA = (
 
 
 async def to_code(config):
-    # Call the validate_lora function here as well, config validation is none in the
+    # Call the validate_lora function here as well, config validation is done in the
     # order as defined in config.yaml, so if lora is configured before sx127x, the
     # sx127x mode will not be set yet.
     validate_lora(config)

--- a/esphome/components/sx127x/lora/__init__.py
+++ b/esphome/components/sx127x/lora/__init__.py
@@ -1,13 +1,36 @@
 from esphome.components.lora import LoRa, lora_schema, new_lora
+import esphome.config_validation as cv
 from esphome.cpp_types import Component
 
-from .. import SX127X_SCHEMA, register_sx127x_client, sx127x_ns
+from .. import (
+    CONF_SX127X_ID,
+    SX127X_SCHEMA,
+    register_sx127x_client,
+    sx127x_modes,
+    sx127x_ns,
+)
 
 SX127xLoRa = sx127x_ns.class_("SX127xLoRa", LoRa, Component)
 
-CONFIG_SCHEMA = lora_schema(SX127xLoRa).extend(SX127X_SCHEMA)
+
+def validate_lora(config):
+    radio_id = str(config[CONF_SX127X_ID])
+    mode = sx127x_modes.get(radio_id)
+    if mode is not None and mode != "LORA":
+        raise cv.Invalid(
+            f"SX127x comonent {radio_id} is not configured in modulation LORA"
+        )
+    return config
+
+
+CONFIG_SCHEMA = lora_schema(SX127xLoRa).extend(SX127X_SCHEMA).add_extra(validate_lora)
 
 
 async def to_code(config):
+    # Call the validate_lora function here as well, config validation is none in the
+    # order as defined in config.yaml, so if lora is configured before sx127x, the
+    # sx127x mode will not be set yet.
+    validate_lora(config)
+
     var = await new_lora(config)
     await register_sx127x_client(var, config)

--- a/esphome/components/sx127x/lora/sx127x_lora.cpp
+++ b/esphome/components/sx127x/lora/sx127x_lora.cpp
@@ -5,28 +5,37 @@
 namespace esphome {
 namespace sx127x {
 
+using namespace esphome::lora;
+
 static const char *const TAG = "sx127x_lora";
 
-void SX127xLoRa::set_frequency(uint32_t frequency) {
+LoRaCommandResponse SX127xLoRa::set_frequency(uint32_t frequency) {
   this->parent_->set_frequency(frequency);
   this->parent_->configure();
+  return LoRaCommandResponse::OK;
 }
 
-void SX127xLoRa::set_mode(lora::LoRaMode mode) {
+LoRaCommandResponse SX127xLoRa::set_mode(LoRaMode mode) {
   switch (mode) {
-    case lora::LoRaMode::SLEEP:
+    case LoRaMode::INIT:
+      this->parent_->configure();
+      break;
+    case LoRaMode::WAKEUP:
+      return LoRaCommandResponse::UNSUPPORTED_FEATURE;
+    case LoRaMode::SLEEP:
       this->parent_->set_mode_sleep();
       break;
-    case lora::LoRaMode::STANDBY:
+    case LoRaMode::STANDBY:
       this->parent_->set_mode_standby();
       break;
-    case lora::LoRaMode::RX:
+    case LoRaMode::RX:
       this->parent_->set_mode_rx();
       break;
-    case lora::LoRaMode::TX:
+    case LoRaMode::TX:
       this->parent_->set_mode_tx();
       break;
   }
+  return LoRaCommandResponse::OK;
 }
 
 }  // namespace sx127x

--- a/esphome/components/sx127x/lora/sx127x_lora.cpp
+++ b/esphome/components/sx127x/lora/sx127x_lora.cpp
@@ -1,0 +1,22 @@
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include "sx127x_lora.h"
+
+namespace esphome {
+namespace sx127x {
+
+static const char *const TAG = "sx127x_lora";
+
+SX127xLoRaListener::SX127xLoRaListener(SX127xLoRa *parent) { this->parent_ = parent; }
+
+void SX127xLoRaListener::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) {
+  this->parent_->packet_received(packet, rssi, snr);
+}
+
+void SX127xLoRa::setup() {
+  LoRa::setup();
+  this->parent_->register_listener(new SX127xLoRaListener(this));
+}
+
+}  // namespace sx127x
+}  // namespace esphome

--- a/esphome/components/sx127x/lora/sx127x_lora.cpp
+++ b/esphome/components/sx127x/lora/sx127x_lora.cpp
@@ -18,5 +18,10 @@ void SX127xLoRa::setup() {
   this->parent_->register_listener(new SX127xLoRaListener(this));
 }
 
+void SX127xLoRa::set_frequency(uint32_t frequency) {
+  this->parent_->set_frequency(frequency);
+  this->parent_->configure();
+}
+
 }  // namespace sx127x
 }  // namespace esphome

--- a/esphome/components/sx127x/lora/sx127x_lora.cpp
+++ b/esphome/components/sx127x/lora/sx127x_lora.cpp
@@ -7,17 +7,6 @@ namespace sx127x {
 
 static const char *const TAG = "sx127x_lora";
 
-SX127xLoRaListener::SX127xLoRaListener(SX127xLoRa *parent) { this->parent_ = parent; }
-
-void SX127xLoRaListener::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) {
-  this->parent_->packet_received(packet, rssi, snr);
-}
-
-void SX127xLoRa::setup() {
-  LoRa::setup();
-  this->parent_->register_listener(new SX127xLoRaListener(this));
-}
-
 void SX127xLoRa::set_frequency(uint32_t frequency) {
   this->parent_->set_frequency(frequency);
   this->parent_->configure();

--- a/esphome/components/sx127x/lora/sx127x_lora.cpp
+++ b/esphome/components/sx127x/lora/sx127x_lora.cpp
@@ -12,5 +12,22 @@ void SX127xLoRa::set_frequency(uint32_t frequency) {
   this->parent_->configure();
 }
 
+void SX127xLoRa::set_mode(lora::LoRaMode mode) {
+  switch (mode) {
+    case lora::LoRaMode::SLEEP:
+      this->parent_->set_mode_sleep();
+      break;
+    case lora::LoRaMode::STANDBY:
+      this->parent_->set_mode_standby();
+      break;
+    case lora::LoRaMode::RX:
+      this->parent_->set_mode_rx();
+      break;
+    case lora::LoRaMode::TX:
+      this->parent_->set_mode_tx();
+      break;
+  }
+}
+
 }  // namespace sx127x
 }  // namespace esphome

--- a/esphome/components/sx127x/lora/sx127x_lora.h
+++ b/esphome/components/sx127x/lora/sx127x_lora.h
@@ -15,7 +15,9 @@ class SX127xLoRa : public lora::LoRa, public Parented<SX127x>, public SX127xList
   }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void send_packet(const std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
+
   void set_frequency(uint32_t frequency) override;
+  void set_mode(lora::LoRaMode mode) override;
 
  protected:
   // size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }

--- a/esphome/components/sx127x/lora/sx127x_lora.h
+++ b/esphome/components/sx127x/lora/sx127x_lora.h
@@ -8,7 +8,9 @@
 namespace esphome {
 namespace sx127x {
 
-class SX127xLoRa : public lora::LoRa, public Parented<SX127x>, public SX127xListener {
+using namespace esphome::lora;
+
+class SX127xLoRa : public LoRa, public Parented<SX127x>, public SX127xListener {
  public:
   void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override {
     this->packet_received(packet, rssi, snr);
@@ -16,8 +18,8 @@ class SX127xLoRa : public lora::LoRa, public Parented<SX127x>, public SX127xList
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void send_packet(const std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
 
-  void set_frequency(uint32_t frequency) override;
-  void set_mode(lora::LoRaMode mode) override;
+  LoRaCommandResponse set_frequency(uint32_t frequency) override;
+  LoRaCommandResponse set_mode(LoRaMode mode) override;
 
   size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
 };

--- a/esphome/components/sx127x/lora/sx127x_lora.h
+++ b/esphome/components/sx127x/lora/sx127x_lora.h
@@ -1,33 +1,24 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/sx127x/sx127x.h"
 #include "esphome/components/lora/lora.h"
 #include <vector>
-#include "../sx127x.h"
 
 namespace esphome {
 namespace sx127x {
 
-class SX127xLoRa;
-
-class SX127xLoRaListener : public SX127xListener {
+class SX127xLoRa : public lora::LoRa, public Parented<SX127x>, public SX127xListener {
  public:
-  SX127xLoRaListener(SX127xLoRa *parent);
-  void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override;
-
- protected:
-  SX127xLoRa *parent_;
-};
-
-class SX127xLoRa : public lora::LoRa, public Parented<SX127x> {
- public:
-  void setup() override;
+  void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override {
+    this->packet_received(packet, rssi, snr);
+  }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void send_packet(const std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
   void set_frequency(uint32_t frequency) override;
 
  protected:
-  // size_t get_max_packet_size() override { return 255u; }
+  // size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
 };
 
 }  // namespace sx127x

--- a/esphome/components/sx127x/lora/sx127x_lora.h
+++ b/esphome/components/sx127x/lora/sx127x_lora.h
@@ -23,7 +23,7 @@ class SX127xLoRa : public lora::LoRa, public Parented<SX127x> {
  public:
   void setup() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
-  void send_packet(std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
+  void send_packet(const std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
 
  protected:
   // size_t get_max_packet_size() override { return 255u; }

--- a/esphome/components/sx127x/lora/sx127x_lora.h
+++ b/esphome/components/sx127x/lora/sx127x_lora.h
@@ -19,8 +19,7 @@ class SX127xLoRa : public lora::LoRa, public Parented<SX127x>, public SX127xList
   void set_frequency(uint32_t frequency) override;
   void set_mode(lora::LoRaMode mode) override;
 
- protected:
-  // size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
+  size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
 };
 
 }  // namespace sx127x

--- a/esphome/components/sx127x/lora/sx127x_lora.h
+++ b/esphome/components/sx127x/lora/sx127x_lora.h
@@ -24,6 +24,7 @@ class SX127xLoRa : public lora::LoRa, public Parented<SX127x> {
   void setup() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void send_packet(const std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
+  void set_frequency(uint32_t frequency) override;
 
  protected:
   // size_t get_max_packet_size() override { return 255u; }

--- a/esphome/components/sx127x/lora/sx127x_lora.h
+++ b/esphome/components/sx127x/lora/sx127x_lora.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/lora/lora.h"
+#include <vector>
+#include "../sx127x.h"
+
+namespace esphome {
+namespace sx127x {
+
+class SX127xLoRa;
+
+class SX127xLoRaListener : public SX127xListener {
+ public:
+  SX127xLoRaListener(SX127xLoRa *parent);
+  void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override;
+
+ protected:
+  SX127xLoRa *parent_;
+};
+
+class SX127xLoRa : public lora::LoRa, public Parented<SX127x> {
+ public:
+  void setup() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+  void send_packet(std::vector<uint8_t> &buf) const override { this->parent_->transmit_packet(buf); }
+
+ protected:
+  // size_t get_max_packet_size() override { return 255u; }
+};
+
+}  // namespace sx127x
+}  // namespace esphome

--- a/tests/components/lora/common.yaml
+++ b/tests/components/lora/common.yaml
@@ -1,0 +1,21 @@
+spi:
+  clk_pin: ${clk_pin}
+  mosi_pin: ${mosi_pin}
+  miso_pin: ${miso_pin}
+
+sx127x:
+  cs_pin: ${cs_pin}
+  rst_pin: ${rst_pin}
+  dio0_pin: ${dio0_pin}
+  frequency: 868100000
+  modulation: LORA
+  bandwidth: 250_0kHz  # Was 125.0
+  spreading_factor: 10 # Was 7 (default)
+  coding_rate: CR_4_8  # Was CR_4_5 (default)
+  rx_start: true
+  rx_floor: -90
+
+lora:
+  - platform: sx127x
+    id: test_lora
+    name: Test LoRa

--- a/tests/components/lora/common.yaml
+++ b/tests/components/lora/common.yaml
@@ -19,6 +19,12 @@ lora:
   - platform: sx127x
     id: test_lora
     name: Test LoRa
+    on_message:
+      then:
+        - lambda: |-
+            ESP_LOGD("lora.on_message", "packet %s", format_hex(x).c_str());
+            ESP_LOGD("lora.on_message", "rssi %.2f", rssi);
+            ESP_LOGD("lora.on_message", "snr %.2f", snr);
 
 packet_transport:
   - platform: lora

--- a/tests/components/lora/common.yaml
+++ b/tests/components/lora/common.yaml
@@ -19,3 +19,8 @@ lora:
   - platform: sx127x
     id: test_lora
     name: Test LoRa
+
+packet_transport:
+  - platform: lora
+    id: packet_transport_lora
+    lora_id: lora_conf

--- a/tests/components/lora/common.yaml
+++ b/tests/components/lora/common.yaml
@@ -9,9 +9,9 @@ sx127x:
   dio0_pin: ${dio0_pin}
   frequency: 868100000
   modulation: LORA
-  bandwidth: 250_0kHz  # Was 125.0
-  spreading_factor: 10 # Was 7 (default)
-  coding_rate: CR_4_8  # Was CR_4_5 (default)
+  bandwidth: 250_0kHz
+  spreading_factor: 10
+  coding_rate: CR_4_8
   rx_start: true
   rx_floor: -90
 

--- a/tests/components/lora/test.esp32-ard.yaml
+++ b/tests/components/lora/test.esp32-ard.yaml
@@ -1,0 +1,9 @@
+substitutions:
+  clk_pin: GPIO5
+  mosi_pin: GPIO27
+  miso_pin: GPIO19
+  cs_pin: GPIO18
+  rst_pin: GPIO23
+  dio0_pin: GPIO26
+
+<<: !include common.yaml

--- a/tests/components/lora/test.esp32-c3-ard.yaml
+++ b/tests/components/lora/test.esp32-c3-ard.yaml
@@ -1,0 +1,9 @@
+substitutions:
+  clk_pin: GPIO5
+  mosi_pin: GPIO18
+  miso_pin: GPIO19
+  cs_pin: GPIO1
+  rst_pin: GPIO2
+  dio0_pin: GPIO3
+
+<<: !include common.yaml

--- a/tests/components/lora/test.esp32-c3-idf.yaml
+++ b/tests/components/lora/test.esp32-c3-idf.yaml
@@ -1,0 +1,9 @@
+substitutions:
+  clk_pin: GPIO5
+  mosi_pin: GPIO18
+  miso_pin: GPIO19
+  cs_pin: GPIO1
+  rst_pin: GPIO2
+  dio0_pin: GPIO3
+
+<<: !include common.yaml

--- a/tests/components/lora/test.esp32-idf.yaml
+++ b/tests/components/lora/test.esp32-idf.yaml
@@ -1,0 +1,9 @@
+substitutions:
+  clk_pin: GPIO5
+  mosi_pin: GPIO27
+  miso_pin: GPIO19
+  cs_pin: GPIO18
+  rst_pin: GPIO23
+  dio0_pin: GPIO26
+
+<<: !include common.yaml

--- a/tests/components/lora/test.esp8266-ard.yaml
+++ b/tests/components/lora/test.esp8266-ard.yaml
@@ -1,0 +1,9 @@
+substitutions:
+  clk_pin: GPIO5
+  mosi_pin: GPIO13
+  miso_pin: GPIO12
+  cs_pin: GPIO1
+  rst_pin: GPIO2
+  dio0_pin: GPIO3
+
+<<: !include common.yaml

--- a/tests/components/lora/test.rp2040-ard.yaml
+++ b/tests/components/lora/test.rp2040-ard.yaml
@@ -1,0 +1,9 @@
+substitutions:
+  clk_pin: GPIO2
+  mosi_pin: GPIO3
+  miso_pin: GPIO4
+  cs_pin: GPIO5
+  rst_pin: GPIO6
+  dio0_pin: GPIO7
+
+<<: !include common.yaml


### PR DESCRIPTION
Local commit to keep track of changes, based on https://github.com/esphome/esphome/pull/8516 and  https://github.com/esphome/esphome/pull/7490 

> Requires any of the above linked PRs to work! They are included as base to this PR but may not be the latest version.
> Unfortunately they cant be pulled separately as this LoRa component slightly modifies the SX12xx components.

Config settings for this addition:
```yaml
external_components:
  - source:
      type: git
      url: https://github.com/dala318/esphome
      ref: lora-comp
    components: [ lora, sx126x, sx127x ]  # only one of 126x and 127x needs to be selected

sx127x:  # or sx126x
  # See the radio PR above for the config of radio you have
  modulation: LORA

lora:
  platform: sx127x  # Or sx126x
  id: lora_conf
  sx127x_id: sx127x_radio
```